### PR TITLE
Exclude some large unused subdirectories from the package

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,14 @@ description = "Rust bindings for the go-jsonnet C API"
 repository = "https://github.com/swlynch99/jsonnet-go-sys"
 documentation = "https://docs.rs/jsonnet-go-sys"
 
+exclude = [
+    "go-jsonnet/testdata",
+    "go-jsonnet/cpp-jsonnet/doc",
+    "go-jsonnet/cpp-jsonnet/test_suite",
+    "go-jsonnet/cpp-jsonnet/case_studies",
+    "go-jsonnet/cpp-jsonnet/perf_tests",
+]
+
 [build-dependencies]
 cc = "1.0.83"
 semver = "1.0.23"


### PR DESCRIPTION
These aren't needed to actually build and were making the package too large to be uploaded to crates.io.